### PR TITLE
Initial PNG context, defining act related terms

### DIFF
--- a/credentials/bc-petroleum-and-natural-gas-title/context.jsonld
+++ b/credentials/bc-petroleum-and-natural-gas-title/context.jsonld
@@ -1,0 +1,82 @@
+{
+    "@context": {
+      "@protected": true,
+  
+      "act": "https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/96361_01#",
+      "site": "https://www2.gov.bc.ca/gov/content/industry/natural-gas-oil/petroleum-natural-gas-tenure",
+      "governance": "https://bcgov.github.io/bc-vcpedia/credentials/bc-petroleum-and-natural-gas-title/governance#",
+  
+      "Law": "https://www.bclaws.gov.bc.ca/",
+      
+      "TenureTitle": {
+        "@id": "site",
+        "@context": {
+          "@protected": true,
+  
+          "id": "@id",
+          "type": "@type",
+  
+          "origin": "governance:origin",
+          "caveats": "governance:caveats"
+        }
+      },
+      
+      "Tract": {
+        "@id": "act:location",
+        "@context": {
+          "@protected": true,
+  
+          "id": "@id",
+          "type": "@type",
+  
+          "rights": "act:d2e1657",
+          "notes": "governance:notes",
+          "zones": "act:zone"
+        }
+      },
+      
+      "Well": {
+        "@id": "act:well",
+        "@context": {
+          "@protected": true,
+  
+          "id": "@id",
+          "type": "@type",
+  
+          "zones": "act:zone"
+        }
+      },
+      
+      "TitleHolder": {
+        "@id": "act:holder+of+a+location",
+        "@context": {
+          "@protected": true,
+  
+          "id": "@id",
+          "type": "@type",
+  
+          "interest": "act:interest"
+        }
+      },
+  
+      "Director": "act:director", 
+      "DrillingPermit": "act:permit",
+      "PetroleumLease": "act:lease",
+      "NaturalGasLease": "act:lease",
+      "PetroleumAndNaturalGasLease": "act:lease",
+  
+      "Lessee": "act:lessee",
+      "Licensee": "act:licensee",
+      "Permittee": "act:permittee",
+  
+      "Petroleum": "act:petroleum",
+      "NaturalGas": "act:natural+gas",
+  
+      "GasWell": "act:gas+well",
+      "StorageWell": "act:storage+well",
+      "PetroleumWell": "act:petroleum+well",
+      "WaterSourceWell": "act:water+source+well"
+  
+    }
+  }
+  


### PR DESCRIPTION
@krobinsonca @Jsyro @bblazicevic let's have a discussion about our context for the CBP demo, I believe here is the best place for it to live since it will be published on the web and is near the governance document.

Currently defines the following terms by linking them to the PNG Act definition section. We have a mix of entities, products and locations, the 3 key component of the Conformity Credential. These are all bound to definitions from the PNG act.

- TenureTitle
- Tract
- Well
- TitleHolder
- Director
- Lessee
- Licensee
- Permittee
- Petroleum
- NaturalGas
