### PR TITLE
Fix capitalization for vocab terms

### DIFF
--- a/credentials/bc-petroleum-and-natural-gas-title/context.jsonld
+++ b/credentials/bc-petroleum-and-natural-gas-title/context.jsonld
@@ -8,11 +8,11 @@
     "url": "https://schema.org/url",
       
     "BCPetroleumNaturalGasTitleCredential": "governance",
-    "Director": "governance:Director",
+    "Director": "governance:director",
     "Law": "https://www.bclaws.gov.bc.ca/",
 
     "LegalEntity": {
-      "@id": "governance:LegalEntity",
+      "@id": "governance:legalentity",
       "@context": {
         "@protected": true,
 
@@ -23,7 +23,7 @@
       }
     },
     "PetroleumNaturalGasTitle": {
-      "@id": "governance:PetroleumNaturalGasTitle",
+      "@id": "governance:petroleumnaturalgastitle",
       "@context": {
         "@protected": true,
 
@@ -33,47 +33,47 @@
         "area": "governance:area",
         "term": "governance:term",
         "caveats": "governance:caveats",
-        "titleType": "governance:titleType",
-        "titleNumber": "governance:titleNumber",
-        "originType": "governance:originType",
-        "originNumber": "governance:originNumber"
+        "titleType": "governance:titletype",
+        "titleNumber": "governance:titlenumber",
+        "originType": "governance:origintype",
+        "originNumber": "governance:originnumber"
       }
     },
     
     "Tract": {
-      "@id": "governance:Tract",
+      "@id": "governance:tract",
       "@context": {
         "@protected": true,
 
         "id": "@id",
         "type": "@type",
 
-        "zones": "governance:tractLocations",
-        "notes": "governance:tractNotes",
+        "zones": "governance:tractlocations",
+        "notes": "governance:tractnotes",
         "rights": {
-          "@id": "governance:tractRights",
+          "@id": "governance:tractrights",
           "@context": {
             "@protected": true,
-            "inclusion": "governance:rightInclusion"
+            "inclusion": "governance:rightinclusion"
           }
         }
       }
     },
     
     "Well": {
-      "@id": "governance:Well",
+      "@id": "governance:well",
       "@context": {
         "@protected": true,
 
         "id": "@id",
         "type": "@type",
 
-        "surfaceLocation": "governance:surfaceLocation"
+        "surfaceLocation": "governance:surfacelocation"
       }
     },
     
     "TitleHolder": {
-      "@id": "governance:TitleHolder",
+      "@id": "governance:titleholder",
       "@context": {
         "@protected": true,
 
@@ -84,17 +84,17 @@
       }
     },
 
-    "DrillingPermit": "governance:Permit",
-    "PetroleumLease": "governance:Lease",
-    "NaturalGasLease": "governance:Lease",
-    "PetroleumAndNaturalGasLease": "governance:Lease",
+    "DrillingPermit": "governance:permit",
+    "PetroleumLease": "governance:lease",
+    "NaturalGasLease": "governance:lease",
+    "PetroleumAndNaturalGasLease": "governance:lease",
 
-    "Lessee": "governance:Lessee",
-    "Licensee": "governance:Licensee",
-    "Permittee": "governance:Permittee",
+    "Lessee": "governance:lessee",
+    "Licensee": "governance:licensee",
+    "Permittee": "governance:permittee",
 
-    "Petroleum": "governance:Petroleum",
-    "NaturalGas": "governance:NaturalGas"
+    "Petroleum": "governance:petroleum",
+    "NaturalGas": "governance:naturalgas"
 
   }
 }


### PR DESCRIPTION
gh-pages removes Capitalization for headers:

ex:
not good -> https://bcgov.github.io/bc-vcpedia/credentials/bc-petroleum-and-natural-gas-title/vocabulary#TitleHolder
good -> https://bcgov.github.io/bc-vcpedia/credentials/bc-petroleum-and-natural-gas-title/vocabulary#titleholder

This PR addresses this in the context file