### PR TITLE
Major Mine Office diddoc

### DIFF
--- a/applications/major-mines-office/did.json
+++ b/applications/major-mines-office/did.json
@@ -13,10 +13,10 @@
     }
   ],
   "authentication": [
-    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#multikey"
+    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#verkey"
   ],
   "assertionMethod": [
-    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#multikey"
+    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#verkey"
   ],
   "service": [
     {

--- a/applications/major-mines-office/did.json
+++ b/applications/major-mines-office/did.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "id": "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office",
+  "verificationMethod": [
+    {
+      "id": "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#verkey",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office",
+      "publicKeyBase58": "Egog81D9Ki413X8WSot8AoT3yhwAxTvURwMnVDfBfYWg"
+    }
+  ],
+  "authentication": [
+    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#multikey"
+  ],
+  "assertionMethod": [
+    "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#multikey"
+  ],
+  "service": [
+    {
+      "id": "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office#linked-domain",
+      "type": "LinkedDomain",
+      "serviceEndpoint": "https://dir.gov.bc.ca/gtds.cgi?show=Branch&organizationCode=EMLI&organizationalUnitCode=MMO"
+    }
+  ]
+}

--- a/applications/major-mines-office/did.json
+++ b/applications/major-mines-office/did.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3.org/ns/did/v1",
+    "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/multikey/v1"
   ],
   "id": "did:web:bcgov.github.io:bc-vcpedia:applications:major-mines-office",


### PR DESCRIPTION
Trying to match the tenure branch setup. 

1) The mines act permits are signed by a did controlled by the "Chief Permitting Officer". ASAIK the Major Mines Office is not a legislated entity. 

2) The ED2019 verkey in here is from the did on the bcovrin TEST ledger from the DEV traction CPO wallet, so these are not the production keys, do we want to add subfolders for dev/test dids?